### PR TITLE
Resolve docker port conflict for crm-redis

### DIFF
--- a/docker-compose-fixed.yml
+++ b/docker-compose-fixed.yml
@@ -1,0 +1,36 @@
+# Fixed docker-compose.yml - removed obsolete 'version' attribute
+# and changed Redis port to avoid conflict
+
+services:
+  crm-mysql:
+    image: mysql:8.0
+    container_name: crm-mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: root_password
+      MYSQL_DATABASE: crm_db
+      MYSQL_USER: crm_user
+      MYSQL_PASSWORD: crm_password
+    ports:
+      - "3307:3306"  # Changed from default 3306 to avoid conflicts
+    volumes:
+      - mysql_data:/var/lib/mysql
+    networks:
+      - crm_network
+
+  crm-redis:
+    image: redis:7-alpine
+    container_name: crm-redis
+    ports:
+      - "6380:6379"  # Changed from 6379 to 6380 to avoid port conflict
+    volumes:
+      - redis_data:/data
+    networks:
+      - crm_network
+
+volumes:
+  mysql_data:
+  redis_data:
+
+networks:
+  crm_network:
+    driver: bridge

--- a/fix-docker-issues.sh
+++ b/fix-docker-issues.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+echo "=== Docker CRM Fix Script ==="
+echo
+
+# Function to check if port is in use
+check_port() {
+    local port=$1
+    if command -v lsof >/dev/null 2>&1; then
+        lsof -i :$port >/dev/null 2>&1
+    elif command -v netstat >/dev/null 2>&1; then
+        netstat -tuln | grep ":$port " >/dev/null 2>&1
+    else
+        # Fallback: try to connect to the port
+        timeout 1 bash -c "cat < /dev/null > /dev/tcp/localhost/$port" 2>/dev/null
+    fi
+}
+
+# Check what's using port 6379
+echo "1. Checking port 6379 usage..."
+if check_port 6379; then
+    echo "   ⚠️  Port 6379 is in use"
+    echo "   Checking for Redis processes..."
+    ps aux | grep redis | grep -v grep || echo "   No Redis processes found"
+    echo "   Checking for Docker containers..."
+    docker ps --format "table {{.Names}}\t{{.Ports}}" 2>/dev/null | grep 6379 || echo "   No Docker containers using port 6379"
+else
+    echo "   ✅ Port 6379 is available"
+fi
+
+echo
+echo "2. Stopping any existing CRM containers..."
+docker stop crm-redis crm-mysql 2>/dev/null || echo "   No containers to stop"
+
+echo
+echo "3. Removing any existing CRM containers..."
+docker rm crm-redis crm-mysql 2>/dev/null || echo "   No containers to remove"
+
+echo
+echo "4. Solutions for your docker-compose.yml:"
+echo "   a) Remove the obsolete 'version:' line from your docker-compose.yml"
+echo "   b) Change Redis port mapping from '6379:6379' to '6380:6379'"
+echo "   c) Or use the fixed docker-compose-fixed.yml provided"
+
+echo
+echo "5. Updated docker-compose.yml should look like:"
+echo "---"
+cat << 'EOF'
+# Remove this line: version: '3.8'
+
+services:
+  crm-mysql:
+    # ... your existing mysql config ...
+    
+  crm-redis:
+    # ... your existing redis config ...
+    ports:
+      - "6380:6379"  # Changed from 6379:6379 to avoid conflict
+EOF
+echo "---"
+
+echo
+echo "6. After fixing, run:"
+echo "   docker-compose up -d"
+echo
+echo "=== Fix complete! ==="


### PR DESCRIPTION
Add example Docker Compose configuration and a diagnostic script to resolve obsolete `version` attribute and Redis port conflict.

---
<a href="https://cursor.com/background-agent?bcId=bc-c5e598fa-dee6-4266-9d05-cda6953f9895">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c5e598fa-dee6-4266-9d05-cda6953f9895">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>